### PR TITLE
Add support for `sszt` in yaml fixtures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ wasmi = "0.4.2"
 rustc-hex = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
+sszt = "0.1.2"
+sha3 = "^0.6"

--- a/bazaar.yaml
+++ b/bazaar.yaml
@@ -5,15 +5,30 @@ beacon_state:
 shard_pre_state:
   exec_env_states:
     - "0000000000000000000000000000000000000000000000000000000000000000"
-    - "22ea9b045f8792170b45ec629c98e1b92bc6a19cd8d0e9f37baaadf2564142f4"
+    - messages:
+      - "list"
 shard_blocks:
   - env: 0
     data: ""
   - env: 0
     data: ""
   - env: 1
-    data: "5c0000005000000001000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000001010101010101010101010101010101010101010101010101010101010101010400000000000000"
+    data:
+      new_messages:
+        - list
+        - timestamp: 1:u64
+          message: 0:u256
+        - timestamp: 2:u64
+          message: 123:u256
+      state:
+        messages:
+          - list
 shard_post_state:
   exec_env_states:
     - "0000000000000000000000000000000000000000000000000000000000000000"
-    - "29505fd952857b5766c759bcb4af58eb8df5a91043540c1398dd987a503127fc"
+    - messsages:
+      - list
+      - timestamp: 1:u64
+        message: 0:u256
+      - timestamp: 2:u64
+        message: 123:u256

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,7 +341,10 @@ impl From<TestShardState> for ShardState {
                 .exec_env_states
                 .iter()
                 .map(|x| {
-                    let hash = Keccak256::digest(&x.to_bytes()[..]);
+                    let hash: Vec<u8> = match x {
+                        TestDataValue::Ssz(_) => x.to_bytes(),
+                        TestDataValue::Object(_) => Keccak256::digest(&x.to_bytes()[..])[..].into(),
+                    };
                     assert!(hash.len() == 32);
                     let mut ret = Bytes32::default();
                     ret.bytes.copy_from_slice(&hash[..]);


### PR DESCRIPTION
In order to make execution environment development and testing on Scout more accessible, I have added support for writing test fixtures directly into the `*.yaml` files. I am using [`sszt`](https://github.com/c-o-l-o-r/sszt), a human-readable representation of SSZ, for cross-language compatibility. The old SSZ literals should continue to function as normal. 

I updated `bazaar.yaml` to support `sszt` as an example and have provided it below for convenience (as well as within the PR):

```yaml
beacon_state:
  execution_scripts:
    - scripts/helloworld/target/wasm32-unknown-unknown/release/phase2_helloworld.wasm
    - scripts/bazaar/target/wasm32-unknown-unknown/release/phase2_bazaar.wasm
shard_pre_state:
  exec_env_states:
    - "0000000000000000000000000000000000000000000000000000000000000000"
    - messages:
      - "list"
shard_blocks:
  - env: 0
    data: ""
  - env: 0
    data: ""
  - env: 1
    data:
      new_messages:
        - list
        - timestamp: 1:u64
          message: 0:u256
        - timestamp: 2:u64
          message: 123:u256
      state:
        messages:
          - list
shard_post_state:
  exec_env_states:
    - "0000000000000000000000000000000000000000000000000000000000000000"
    - messsages:
      - list
      - timestamp: 1:u64
        message: 0:u256
      - timestamp: 2:u64
        message: 123:u256
```